### PR TITLE
Add files via upload

### DIFF
--- a/mach-eap900h.c
+++ b/mach-eap900h.c
@@ -1,0 +1,180 @@
+/*
+ * EAP900H board support
+ *
+ * Copyright (c) 2012 Qualcomm Atheros
+ * Copyright (c) 2012-2013 Marek Lindner <marek@open-mesh.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include <linux/platform_device.h>
+#include <linux/ar8216_platform.h>
+#include <linux/ath9k_platform.h>
+
+#include <asm/mach-ath79/ar71xx_regs.h>
+#include <linux/platform_data/phy-at803x.h>
+
+#include "common.h"
+#include "dev-ap9x-pci.h"
+#include "dev-gpio-buttons.h"
+#include "dev-eth.h"
+#include "dev-leds-gpio.h"
+#include "dev-m25p80.h"
+#include "dev-wmac.h"
+#include "machtypes.h"
+#include "pci.h"
+
+#define EAP900H_GPIO_LED_LAN		12
+#define EAP900H_GPIO_LED_WLAN_2G		13
+#define EAP900H_GPIO_LED_STATUS_GREEN	19
+#define EAP900H_GPIO_LED_STATUS_RED	21
+#define EAP900H_GPIO_LED_POWER		22
+#define EAP900H_GPIO_LED_WLAN_5G		23
+
+#define EAP900H_GPIO_BTN_RESET		17
+
+#define EAP900H_KEYS_POLL_INTERVAL	20	/* msecs */
+#define EAP900H_KEYS_DEBOUNCE_INTERVAL	(3 * EAP900H_KEYS_POLL_INTERVAL)
+
+#define EAP900H_MAC0_OFFSET		0
+#define EAP900H_WMAC_CALDATA_OFFSET	0x1000
+#define EAP900H_PCIE_CALDATA_OFFSET	0x5000
+
+static struct gpio_led eap900h_leds_gpio[] __initdata = {
+	{
+		.name		= "eap900h:blue:power",
+		.gpio		= EAP900H_GPIO_LED_POWER,
+		.active_low	= 1,
+	},
+	{
+		.name		= "eap900h:blue:wan",
+		.gpio		= EAP900H_GPIO_LED_LAN,
+		.active_low	= 1,
+	},
+	{
+		.name		= "eap900h:blue:wlan24",
+		.gpio		= EAP900H_GPIO_LED_WLAN_2G,
+		.active_low	= 1,
+	},
+	{
+		.name		= "eap900h:blue:wlan58",
+		.gpio		= EAP900H_GPIO_LED_WLAN_5G,
+		.active_low	= 1,
+	},
+	{
+		.name		= "eap900h:green:status",
+		.gpio		= EAP900H_GPIO_LED_STATUS_GREEN,
+		.active_low	= 1,
+	},
+	{
+		.name		= "eap900h:red:status",
+		.gpio		= EAP900H_GPIO_LED_STATUS_RED,
+		.active_low	= 1,
+	},
+};
+
+static struct gpio_keys_button eap900h_gpio_keys[] __initdata = {
+	{
+		.desc		= "Reset button",
+		.type		= EV_KEY,
+		.code		= KEY_RESTART,
+		.debounce_interval = EAP900H_KEYS_DEBOUNCE_INTERVAL,
+		.gpio		= EAP900H_GPIO_BTN_RESET,
+		.active_low	= 1,
+	},
+};
+
+static struct at803x_platform_data eap900h_at803x_data = {
+	.disable_smarteee = 1,
+	.enable_rgmii_rx_delay = 1,
+	.enable_rgmii_tx_delay = 0,
+	.fixup_rgmii_tx_delay = 1,
+};
+
+static struct mdio_board_info eap900h_mdio0_info[] = {
+	{
+		.bus_id = "ag71xx-mdio.0",
+		.phy_addr = 5,
+		.platform_data = &eap900h_at803x_data,
+	},
+};
+
+static void __init eap900h_setup_qca955x_eth_cfg(u32 mask,
+					       unsigned int rxd,
+					       unsigned int rxdv,
+					       unsigned int txd,
+					       unsigned int txe)
+{
+	void __iomem *base;
+	u32 t;
+
+	base = ioremap(QCA955X_GMAC_BASE, QCA955X_GMAC_SIZE);
+
+	t = mask;
+	t |= rxd << QCA955X_ETH_CFG_RXD_DELAY_SHIFT;
+	t |= rxdv << QCA955X_ETH_CFG_RDV_DELAY_SHIFT;
+	t |= txd << QCA955X_ETH_CFG_TXD_DELAY_SHIFT;
+	t |= txe << QCA955X_ETH_CFG_TXE_DELAY_SHIFT;
+
+	__raw_writel(t, base + QCA955X_GMAC_REG_ETH_CFG);
+
+	iounmap(base);
+}
+
+static void __init eap900h_setup(void)
+{
+	u8 *art = (u8 *)KSEG1ADDR(0x1fff0000);
+	u8 mac[6], pcie_mac[6];
+	struct ath9k_platform_data *pdata;
+
+	ath79_eth0_pll_data.pll_1000 = 0xae000000;
+	ath79_eth0_pll_data.pll_100 = 0xa0000101;
+	ath79_eth0_pll_data.pll_10 = 0xa0001313;
+
+	ath79_register_m25p80(NULL);
+
+	ath79_register_leds_gpio(-1, ARRAY_SIZE(eap900h_leds_gpio),
+				 eap900h_leds_gpio);
+	ath79_register_gpio_keys_polled(-1, EAP900H_KEYS_POLL_INTERVAL,
+					ARRAY_SIZE(eap900h_gpio_keys),
+					eap900h_gpio_keys);
+
+	ath79_init_mac(mac, art + EAP900H_MAC0_OFFSET, 1);
+	ath79_register_wmac(art + EAP900H_WMAC_CALDATA_OFFSET, mac);
+	ath79_init_mac(pcie_mac, art + EAP900H_MAC0_OFFSET, 16);
+	ap91_pci_init(art + EAP900H_PCIE_CALDATA_OFFSET, pcie_mac);
+	pdata = ap9x_pci_get_wmac_data(0);
+	if (!pdata) {
+		pr_err("eap900h: unable to get address of wlan data\n");
+		return;
+	}
+	pdata->use_eeprom = true;
+
+	eap900h_setup_qca955x_eth_cfg(QCA955X_ETH_CFG_RGMII_EN, 3, 3, 0, 0);
+	ath79_register_mdio(0, 0x0);
+
+	mdiobus_register_board_info(eap900h_mdio0_info,
+				    ARRAY_SIZE(eap900h_mdio0_info));
+
+	ath79_init_mac(ath79_eth0_data.mac_addr, art + EAP900H_MAC0_OFFSET, 0);
+
+	/* GMAC0 is connected to the RMGII interface */
+	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_RGMII;
+	ath79_eth0_data.phy_mask = BIT(5);
+	ath79_eth0_data.mii_bus_dev = &ath79_mdio0_device.dev;
+
+	ath79_register_eth(0);
+}
+
+MIPS_MACHINE(ATH79_MACH_EAP900H, "EAP900H", "Engenius EAP900H", eap900h_setup);


### PR DESCRIPTION
Engenius EAP900H Support

FCCID A8J-EAP900H

EAP900H similar to OpenMesh MR900.

CPU1: Qualcomm Atheros QCA9558
FLA1: ? MiB (Macronix Model?)
RAM1: 128 MiB (Nanya NT5TU32M16DG-AC × 2)
Expansion IFs: none specified

WI1 chip1: Qualcomm Atheros QCA9558
WI1 802dot11 protocols: bgn
WI1 MIMO config: 3x3:3
WI1 antenna connector: U.FL
WI2 module: EnGenius EMP5608H
WI2 module IF: Mini PCIe (oversized)
WI2 chip1: Atheros AR9580
WI2 802dot11 protocols: an
WI2 MIMO config: 3x3:3
WI2 antenna connector: U.FL

ETH chip1: Qualcomm Atheros QCA9558
ETH chip2: Atheros AR8035-A
LAN speed: 1G
LAN ports: 1

Test with LEDE 17.01.7 , upgrade can be don through oem web gui.

GPIO Layout:
#define EAP900H_GPIO_LED_LAN		12
#define EAP900H_GPIO_LED_WLAN_2G		13
#define EAP900H_GPIO_LED_STATUS_GREEN	19
#define EAP900H_GPIO_LED_STATUS_RED	21
#define EAP900H_GPIO_LED_POWER		22
#define EAP900H_GPIO_LED_WLAN_5G		23
#define EAP900H_GPIO_BTN_RESET		17
 